### PR TITLE
feat: allow more than 5 download threads

### DIFF
--- a/src/main/xerus/monstercat/downloader/TabDownloader.kt
+++ b/src/main/xerus/monstercat/downloader/TabDownloader.kt
@@ -517,7 +517,7 @@ class TabDownloader: VTab() {
 			}
 			add(cancelButton.allowExpand(vertical = false))
 			
-			addLabeled("Download Threads", intSpinner(0, 99) syncWith DOWNLOADTHREADS)
+			addLabeled("Download Threads", intSpinner(0, 100) syncWith DOWNLOADTHREADS)
 			val progressLabel = Label("0 / ${state.total} Errors: 0")
 			val progressBar = ProgressBar()
 			add(StackPane(progressBar.allowExpand(vertical = false), progressLabel))

--- a/src/main/xerus/monstercat/downloader/TabDownloader.kt
+++ b/src/main/xerus/monstercat/downloader/TabDownloader.kt
@@ -517,7 +517,7 @@ class TabDownloader: VTab() {
 			}
 			add(cancelButton.allowExpand(vertical = false))
 			
-			addLabeled("Download Threads", intSpinner(0, 5) syncWith DOWNLOADTHREADS)
+			addLabeled("Download Threads", intSpinner(0, 99) syncWith DOWNLOADTHREADS)
 			val progressLabel = Label("0 / ${state.total} Errors: 0")
 			val progressBar = ProgressBar()
 			add(StackPane(progressBar.allowExpand(vertical = false), progressLabel))


### PR DESCRIPTION
**NOTE** Created with GitHub's online editor. Also, I have absolutely zero experience in Java

From looking at the code, there shouldn't be any reason to limit the download thread count to 5. I have gigabit and am only able to download at around 200 Mbps (it's not my disk or networking, I've checked). This PR opens up the `intSpinner` to allow up to 99 threads when downloading.